### PR TITLE
Mount integrations router

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,7 @@ import { workflowRoutes } from './workflows/routes/workflowRoutes';
 import { executionRoutes } from './workflows/routes/executionRoutes';
 import { templateRoutes } from './workflows/routes/templateRoutes';
 import { webhookRoutes } from './workflows/routes/webhookRoutes';
+import integrationsRoutes from './integrations/routes/integrationRoutes';
 
 // WebSocket server
 import { WebSocketServer } from './websocket/websocketServer';
@@ -96,6 +97,7 @@ app.use('/api/workflows', workflowRoutes);
 app.use('/api/executions', executionRoutes);
 app.use('/api/templates', templateRoutes);
 app.use('/api/webhooks', webhookRoutes);
+app.use('/api/integrations', integrationsRoutes);
 
 // Error handling middleware (must be last)
 app.use(errorHandler);


### PR DESCRIPTION
## Summary
- import the integrations feature router into the Express app entry point
- expose the integrations API under /api/integrations ahead of the 404 handler so the routes are reachable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68c9f5a2aa1883238eac3f5d0e127ad4