### PR TITLE
Secure API connector credential encryption

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --write \"**/*.{js,ts,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,ts,json,md}\"",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "migrate:re-encrypt-api-connections": "tsx scripts/reEncryptApiConnections.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.8.0",

--- a/backend/scripts/reEncryptApiConnections.ts
+++ b/backend/scripts/reEncryptApiConnections.ts
@@ -1,0 +1,86 @@
+import { PrismaClient } from '@prisma/client';
+import type { AuthConfig } from '../src/integrations/apiConnector';
+import {
+  encryptPayload,
+  ensureEncryptionKey,
+  isEncryptedPayload
+} from '../src/utils/encryption';
+
+const prisma = new PrismaClient();
+
+function decodeLegacyAuthConfig(storedAuth: any): AuthConfig | null {
+  if (!storedAuth) {
+    return null;
+  }
+
+  try {
+    if (typeof storedAuth.credentials === 'string') {
+      const decoded = Buffer.from(storedAuth.credentials, 'base64').toString();
+      const credentials = JSON.parse(decoded);
+      return {
+        ...storedAuth,
+        credentials
+      } as AuthConfig;
+    }
+
+    return storedAuth as AuthConfig;
+  } catch (error) {
+    console.warn('Skipping API connection with unreadable credentials', error);
+    return null;
+  }
+}
+
+async function main(): Promise<void> {
+  const rawKey = process.env.API_CONNECTOR_ENCRYPTION_KEY || process.env.ENCRYPTION_KEY;
+  const encryptionKey = ensureEncryptionKey(rawKey, 'API connection re-encryption');
+
+  const connections = await prisma.apiConnection.findMany();
+  let migrated = 0;
+
+  for (const connection of connections) {
+    let storedAuth = connection.authentication as any;
+
+    if (!storedAuth) {
+      continue;
+    }
+
+    if (typeof storedAuth === 'string') {
+      try {
+        storedAuth = JSON.parse(storedAuth);
+      } catch (error) {
+        console.warn(`Skipping API connection ${connection.id}: authentication payload is not valid JSON`, error);
+        continue;
+      }
+    }
+
+    if (isEncryptedPayload(storedAuth)) {
+      continue;
+    }
+
+    const authConfig = decodeLegacyAuthConfig(storedAuth);
+    if (!authConfig) {
+      continue;
+    }
+
+    const encrypted = encryptPayload(authConfig, encryptionKey);
+    await prisma.apiConnection.update({
+      where: { id: connection.id },
+      data: { authentication: encrypted }
+    });
+
+    migrated += 1;
+    console.log(`Re-encrypted API connection ${connection.id}`);
+  }
+
+  console.log(`Re-encrypted ${migrated} API connection(s).`);
+}
+
+main()
+  .catch((error) => {
+    console.error('Failed to re-encrypt API connections', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+

--- a/backend/src/utils/encryption.ts
+++ b/backend/src/utils/encryption.ts
@@ -1,0 +1,113 @@
+import crypto from 'crypto';
+
+const ENCRYPTION_ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH_BYTES = 12; // 96 bits recommended for GCM
+const AUTH_TAG_LENGTH_BYTES = 16;
+
+export interface EncryptedPayload {
+  iv: string;
+  ciphertext: string;
+}
+
+function isBase64(value: string): boolean {
+  return /^[A-Za-z0-9+/]+={0,2}$/.test(value) && value.length % 4 === 0;
+}
+
+function isHex(value: string): boolean {
+  return /^[0-9a-fA-F]+$/.test(value) && value.length % 2 === 0;
+}
+
+function deriveKey(rawKey: string): Buffer {
+  const trimmed = rawKey.trim();
+  let keyMaterial: Buffer;
+
+  if (isBase64(trimmed)) {
+    try {
+      const decoded = Buffer.from(trimmed, 'base64');
+      if (decoded.length > 0) {
+        keyMaterial = decoded;
+      } else {
+        keyMaterial = Buffer.from(trimmed, 'utf8');
+      }
+    } catch {
+      keyMaterial = Buffer.from(trimmed, 'utf8');
+    }
+  } else if (isHex(trimmed)) {
+    try {
+      keyMaterial = Buffer.from(trimmed, 'hex');
+    } catch {
+      keyMaterial = Buffer.from(trimmed, 'utf8');
+    }
+  } else {
+    keyMaterial = Buffer.from(trimmed, 'utf8');
+  }
+
+  return crypto.createHash('sha256').update(keyMaterial).digest();
+}
+
+export function isEncryptedPayload(value: unknown): value is EncryptedPayload {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Record<string, unknown>;
+  return typeof candidate.iv === 'string' && typeof candidate.ciphertext === 'string';
+}
+
+export function encryptPayload(payload: unknown, rawKey: string): EncryptedPayload {
+  if (!rawKey || rawKey.trim().length === 0) {
+    throw new Error('Encryption key must be provided');
+  }
+
+  const key = deriveKey(rawKey);
+  const iv = crypto.randomBytes(IV_LENGTH_BYTES);
+  const cipher = crypto.createCipheriv(ENCRYPTION_ALGORITHM, key, iv);
+
+  const plaintextBuffer = Buffer.from(JSON.stringify(payload), 'utf8');
+  const encrypted = Buffer.concat([cipher.update(plaintextBuffer), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  const combined = Buffer.concat([authTag, encrypted]);
+
+  return {
+    iv: iv.toString('base64'),
+    ciphertext: combined.toString('base64')
+  };
+}
+
+export function decryptPayload<T>(payload: EncryptedPayload, rawKey: string): T {
+  if (!rawKey || rawKey.trim().length === 0) {
+    throw new Error('Encryption key must be provided');
+  }
+
+  const key = deriveKey(rawKey);
+  const iv = Buffer.from(payload.iv, 'base64');
+  if (iv.length !== IV_LENGTH_BYTES) {
+    throw new Error('Invalid initialization vector');
+  }
+
+  const combined = Buffer.from(payload.ciphertext, 'base64');
+  if (combined.length < AUTH_TAG_LENGTH_BYTES) {
+    throw new Error('Invalid ciphertext payload');
+  }
+
+  const authTag = combined.subarray(0, AUTH_TAG_LENGTH_BYTES);
+  const encrypted = combined.subarray(AUTH_TAG_LENGTH_BYTES);
+
+  const decipher = crypto.createDecipheriv(ENCRYPTION_ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]).toString('utf8');
+
+  return JSON.parse(decrypted) as T;
+}
+
+export function ensureEncryptionKey(key: string | null | undefined, context: string): string {
+  const trimmed = key?.trim();
+  if (!trimmed) {
+    throw new Error(`${context}: encryption key is not configured`);
+  }
+
+  return trimmed;
+}
+


### PR DESCRIPTION
## Summary
- add a hardened AES-256-GCM helper that normalizes env-supplied keys and returns structured { iv, ciphertext } blobs
- enforce encryption key availability for API connector workflows and persist encrypted authentication payloads
- provide a Prisma backfill script and npm helper to re-encrypt legacy API connection records with the new format

## Testing
- `npm install` *(fails: @types/archiver@^6.0.4 not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c9f596930c83239ab3bfa26050b1a7