### PR TITLE
Secure OAuth2 credential encryption

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -39,6 +39,7 @@ EMAIL_FROM=noreply@chatbot-platform.com
 COOKIE_SECRET=your_cookie_secret_min_32_chars
 SESSION_SECRET=your_session_secret_min_32_chars
 CSRF_TOKEN_SECRET=your_csrf_secret_min_32_chars
+OAUTH2_ENCRYPTION_KEY=your_32_byte_encryption_key
 
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=60000

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "format:check": "prettier --check \"**/*.{js,ts,json,md}\"",
     "test": "jest",
     "test:watch": "jest --watch",
-    "migrate:re-encrypt-api-connections": "tsx scripts/reEncryptApiConnections.ts"
+    "migrate:re-encrypt-api-connections": "tsx scripts/reEncryptApiConnections.ts",
+    "migrate:re-encrypt-oauth2": "tsx scripts/reEncryptOAuth2Data.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.8.0",

--- a/backend/scripts/reEncryptOAuth2Data.ts
+++ b/backend/scripts/reEncryptOAuth2Data.ts
@@ -1,0 +1,165 @@
+import { PrismaClient } from '@prisma/client';
+import {
+  encryptPayload,
+  ensureEncryptionKey,
+  EncryptedPayload,
+  isEncryptedPayload
+} from '../src/utils/encryption';
+
+const prisma = new PrismaClient();
+
+function serialize(payload: EncryptedPayload): string {
+  return JSON.stringify(payload);
+}
+
+function parseEncrypted(value: unknown): EncryptedPayload | null {
+  if (!value) {
+    return null;
+  }
+
+  if (isEncryptedPayload(value)) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (isEncryptedPayload(parsed)) {
+        return parsed;
+      }
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function decodeLegacyClientSecret(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    const decoded = Buffer.from(trimmed, 'base64').toString('utf8');
+    if (
+      decoded &&
+      Buffer.from(decoded, 'utf8').toString('base64').replace(/=+$/, '') === trimmed.replace(/=+$/, '')
+    ) {
+      return decoded;
+    }
+  } catch {
+    // Not base64 encoded – fall through to returning trimmed value
+  }
+
+  return trimmed;
+}
+
+function decodeLegacyToken(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+async function reEncryptProviders(encryptionKey: string): Promise<number> {
+  const providers = await prisma.oAuth2Provider.findMany();
+  let migrated = 0;
+
+  for (const provider of providers) {
+    const currentSecret = provider.clientSecret as unknown;
+    if (parseEncrypted(currentSecret)) {
+      continue;
+    }
+
+    const legacySecret = decodeLegacyClientSecret(currentSecret);
+    if (!legacySecret) {
+      console.warn(`Skipping OAuth2 provider ${provider.id}: missing or unreadable client secret`);
+      continue;
+    }
+
+    const encryptedSecret = serialize(encryptPayload(legacySecret, encryptionKey));
+    await prisma.oAuth2Provider.update({
+      where: { id: provider.id },
+      data: { clientSecret: encryptedSecret }
+    });
+
+    migrated += 1;
+    console.log(`Re-encrypted OAuth2 provider ${provider.id}`);
+  }
+
+  return migrated;
+}
+
+async function reEncryptConnections(encryptionKey: string): Promise<number> {
+  const connections = await prisma.oAuth2Connection.findMany();
+  let migrated = 0;
+
+  for (const connection of connections) {
+    const updates: { accessToken?: string; refreshToken?: string | null } = {};
+
+    if (!parseEncrypted(connection.accessToken as unknown)) {
+      const legacyAccessToken = decodeLegacyToken(connection.accessToken as unknown);
+      if (legacyAccessToken) {
+        updates.accessToken = serialize(encryptPayload(legacyAccessToken, encryptionKey));
+      }
+    }
+
+    if (connection.refreshToken && !parseEncrypted(connection.refreshToken as unknown)) {
+      const legacyRefreshToken = decodeLegacyToken(connection.refreshToken as unknown);
+      if (legacyRefreshToken) {
+        updates.refreshToken = serialize(encryptPayload(legacyRefreshToken, encryptionKey));
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      continue;
+    }
+
+    await prisma.oAuth2Connection.update({
+      where: { id: connection.id },
+      data: updates
+    });
+
+    migrated += 1;
+    console.log(`Re-encrypted OAuth2 connection ${connection.id}`);
+  }
+
+  return migrated;
+}
+
+async function main(): Promise<void> {
+  const rawKey =
+    process.env.OAUTH2_ENCRYPTION_KEY ||
+    process.env.API_CONNECTOR_ENCRYPTION_KEY ||
+    process.env.ENCRYPTION_KEY;
+  const encryptionKey = ensureEncryptionKey(rawKey, 'OAuth2 re-encryption');
+
+  const providerCount = await reEncryptProviders(encryptionKey);
+  const connectionCount = await reEncryptConnections(encryptionKey);
+
+  console.log(
+    `Re-encrypted ${providerCount} OAuth2 provider(s) and ${connectionCount} OAuth2 connection(s).`
+  );
+}
+
+main()
+  .catch(error => {
+    console.error('Failed to re-encrypt OAuth2 secrets', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/backend/src/integrations/__tests__/oauth2Manager.encryption.test.ts
+++ b/backend/src/integrations/__tests__/oauth2Manager.encryption.test.ts
@@ -1,0 +1,218 @@
+import { OAuth2Manager } from '../oauth2Manager';
+import { encryptPayload, isEncryptedPayload } from '../../utils/encryption';
+
+jest.mock(
+  'axios',
+  () => ({
+    post: jest.fn(),
+    get: jest.fn()
+  }),
+  { virtual: true }
+);
+
+describe('OAuth2Manager encryption', () => {
+  let prismaMock: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    prismaMock = {
+      oAuth2Provider: {
+        create: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+        findFirst: jest.fn()
+      },
+      oAuth2Connection: {
+        create: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+        delete: jest.fn()
+      }
+    };
+  });
+
+  it('encrypts client secrets when registering providers', async () => {
+    const manager = new OAuth2Manager(prismaMock as any);
+    const providerData = {
+      name: 'Test Provider',
+      authUrl: 'https://example.com/auth',
+      tokenUrl: 'https://example.com/token',
+      clientId: 'client-id',
+      clientSecret: 'super-secret',
+      scopes: ['email'],
+      redirectUri: 'https://app.example.com/callback',
+      isActive: true
+    };
+
+    (prismaMock.oAuth2Provider.create as jest.Mock).mockImplementation(async ({ data }) => ({
+      id: 'provider-1',
+      tenantId: data.tenantId,
+      name: data.name,
+      authUrl: data.authUrl,
+      tokenUrl: data.tokenUrl,
+      clientId: data.clientId,
+      clientSecret: data.clientSecret,
+      scopes: data.scopes,
+      redirectUri: data.redirectUri,
+      isActive: data.isActive,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }));
+
+    const providerId = await manager.registerProvider('tenant-1', providerData);
+    expect(providerId).toBe('provider-1');
+
+    const storedSecret = (prismaMock.oAuth2Provider.create as jest.Mock).mock.calls[0][0].data
+      .clientSecret;
+
+    expect(typeof storedSecret).toBe('string');
+    expect(storedSecret).not.toContain(providerData.clientSecret);
+
+    const parsed = JSON.parse(storedSecret);
+    expect(isEncryptedPayload(parsed)).toBe(true);
+
+    const cachedProvider = (manager as any).providers.get(providerId);
+    expect(cachedProvider.clientSecret).toBe(providerData.clientSecret);
+
+    expect((console.error as jest.Mock).mock.calls.join('')).not.toContain(providerData.clientSecret);
+  });
+
+  it('encrypts access and refresh tokens when saving connections', async () => {
+    const manager = new OAuth2Manager(prismaMock as any);
+    const tokens = {
+      accessToken: 'access-token-value',
+      refreshToken: 'refresh-token-value',
+      tokenType: 'Bearer',
+      expiresIn: 3600,
+      expiresAt: new Date(Date.now() + 3600 * 1000),
+      scope: 'email'
+    };
+
+    (prismaMock.oAuth2Connection.create as jest.Mock).mockImplementation(async ({ data }) => ({
+      id: 'connection-1',
+      userId: data.userId,
+      tenantId: data.tenantId,
+      providerId: data.providerId,
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+      tokenType: data.tokenType,
+      expiresAt: data.expiresAt,
+      scope: data.scope,
+      userInfo: data.userInfo,
+      isActive: data.isActive,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }));
+
+    const connection = await (manager as any).saveConnection(
+      'user-1',
+      'tenant-1',
+      'provider-1',
+      tokens,
+      { email: 'user@example.com' }
+    );
+
+    const savedData = (prismaMock.oAuth2Connection.create as jest.Mock).mock.calls[0][0].data;
+    const accessPayload = JSON.parse(savedData.accessToken);
+    expect(isEncryptedPayload(accessPayload)).toBe(true);
+    expect(savedData.accessToken).not.toContain(tokens.accessToken);
+
+    const refreshPayload = JSON.parse(savedData.refreshToken);
+    expect(isEncryptedPayload(refreshPayload)).toBe(true);
+    expect(savedData.refreshToken).not.toContain(tokens.refreshToken as string);
+
+    expect(connection.tokens.accessToken).toBe(tokens.accessToken);
+    expect(connection.tokens.refreshToken).toBe(tokens.refreshToken);
+
+    expect((console.error as jest.Mock).mock.calls.join('')).not.toContain(tokens.accessToken);
+    expect((console.error as jest.Mock).mock.calls.join('')).not.toContain(tokens.refreshToken as string);
+  });
+
+  it('decrypts encrypted providers during load', async () => {
+    const encryptionKey = process.env.OAUTH2_ENCRYPTION_KEY as string;
+    const encryptedSecret = JSON.stringify(encryptPayload('cached-secret', encryptionKey));
+
+    (prismaMock.oAuth2Provider.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'provider-42',
+        tenantId: 'tenant-42',
+        name: 'Encrypted Provider',
+        authUrl: 'https://example.com/auth',
+        tokenUrl: 'https://example.com/token',
+        clientId: 'client-42',
+        clientSecret: encryptedSecret,
+        scopes: ['profile'],
+        redirectUri: 'https://app.example.com/callback',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ]);
+
+    const manager = new OAuth2Manager(prismaMock as any);
+    await (manager as any).loadProviders();
+
+    const cached = (manager as any).providers.get('provider-42');
+    expect(cached).toBeDefined();
+    expect(cached.clientSecret).toBe('cached-secret');
+  });
+
+  it('decodes legacy base64 client secrets during load', async () => {
+    const legacySecret = Buffer.from('legacy-secret', 'utf8').toString('base64');
+
+    (prismaMock.oAuth2Provider.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'provider-legacy',
+        tenantId: 'tenant-legacy',
+        name: 'Legacy Provider',
+        authUrl: 'https://example.com/auth',
+        tokenUrl: 'https://example.com/token',
+        clientId: 'legacy-client',
+        clientSecret: legacySecret,
+        scopes: ['email'],
+        redirectUri: 'https://app.example.com/callback',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ]);
+
+    const manager = new OAuth2Manager(prismaMock as any);
+    await (manager as any).loadProviders();
+
+    const cached = (manager as any).providers.get('provider-legacy');
+    expect(cached).toBeDefined();
+    expect(cached.clientSecret).toBe('legacy-secret');
+  });
+
+  it('decrypts stored tokens when retrieving user connections', async () => {
+    const manager = new OAuth2Manager(prismaMock as any);
+    const encryptionKey = process.env.OAUTH2_ENCRYPTION_KEY as string;
+    const encryptedAccess = JSON.stringify(encryptPayload('stored-access', encryptionKey));
+    const encryptedRefresh = JSON.stringify(encryptPayload('stored-refresh', encryptionKey));
+
+    (prismaMock.oAuth2Connection.findMany as jest.Mock).mockResolvedValueOnce([
+      {
+        id: 'connection-55',
+        userId: 'user-55',
+        tenantId: 'tenant-55',
+        providerId: 'provider-55',
+        accessToken: encryptedAccess,
+        refreshToken: encryptedRefresh,
+        tokenType: 'Bearer',
+        expiresAt: new Date(Date.now() + 1000),
+        scope: 'email',
+        userInfo: { email: 'user@example.com' },
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ]);
+
+    const connections = await manager.getUserConnections('user-55', 'tenant-55');
+    expect(connections).toHaveLength(1);
+    expect(connections[0].tokens.accessToken).toBe('stored-access');
+    expect(connections[0].tokens.refreshToken).toBe('stored-refresh');
+  });
+});

--- a/backend/src/tests/setup.ts
+++ b/backend/src/tests/setup.ts
@@ -20,6 +20,7 @@ process.env.JWT_SECRET = 'test-jwt-secret-that-is-at-least-32-characters-long';
 process.env.BCRYPT_ROUNDS = '4'; // Lower rounds for faster tests
 process.env.DATABASE_URL = 'postgresql://postgres:postgres@localhost:5432/chatbot_platform_test';
 process.env.N8N_ENCRYPTION_KEY = 'ZGV2ZWxvcG1lbnRFbmNyeXB0aW9uS2V5MzJBQkNERUY=';
+process.env.OAUTH2_ENCRYPTION_KEY = 'test-oauth2-encryption-key-32-bytes!!';
 
 // Global test timeout
 jest.setTimeout(30000);


### PR DESCRIPTION
## Summary
- adopt shared AES-GCM helpers in the OAuth2 manager, require an encryption key for mutating flows, and decrypt tokens safely while preserving legacy fallbacks
- add a re-encryption utility to migrate existing provider and connection secrets to the new `{ iv, ciphertext }` structure
- document the OAuth2 encryption key in env defaults, configure test fixtures, and cover encryption behaviour with mocked Prisma-based unit tests

## Testing
- `npx jest integrations/__tests__/oauth2Manager.encryption.test.ts`
- `npm test` *(fails: existing auth/tenant suites expect mocked Prisma + tenant context)*

------
https://chatgpt.com/codex/tasks/task_b_68c9fed4c5148323bb39a1791441e3ee