### PR TITLE
Add workflow permission persistence for workflow executor

### DIFF
--- a/backend/prisma/migrations/20241006120000_add_workflow_permissions_and_confirmations/migration.sql
+++ b/backend/prisma/migrations/20241006120000_add_workflow_permissions_and_confirmations/migration.sql
@@ -1,0 +1,55 @@
+-- Create table for workflow-level permissions
+CREATE TABLE "workflow_permissions" (
+  "id" TEXT NOT NULL,
+  "tenantId" TEXT NOT NULL,
+  "workflowId" TEXT NOT NULL,
+  "userId" TEXT,
+  "role" "Role",
+  "canView" BOOLEAN NOT NULL DEFAULT false,
+  "canExecute" BOOLEAN NOT NULL DEFAULT false,
+  "canCancel" BOOLEAN NOT NULL DEFAULT false,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "workflow_permissions_pkey" PRIMARY KEY ("id")
+);
+
+-- Create table for pending workflow confirmations
+CREATE TABLE "workflow_confirmations" (
+  "id" TEXT NOT NULL,
+  "tenantId" TEXT NOT NULL,
+  "workflowId" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "requestData" JSONB NOT NULL,
+  "expiresAt" TIMESTAMP(3) NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "workflow_confirmations_pkey" PRIMARY KEY ("id")
+);
+
+-- Indexes to support permission lookups
+CREATE INDEX "workflow_permissions_tenantId_idx" ON "workflow_permissions" ("tenantId");
+CREATE INDEX "workflow_permissions_workflowId_idx" ON "workflow_permissions" ("workflowId");
+CREATE INDEX "workflow_permissions_userId_idx" ON "workflow_permissions" ("userId");
+CREATE INDEX "workflow_permissions_role_idx" ON "workflow_permissions" ("role");
+
+-- Indexes to support confirmation lookups and cleanup
+CREATE INDEX "workflow_confirmations_tenantId_idx" ON "workflow_confirmations" ("tenantId");
+CREATE INDEX "workflow_confirmations_workflowId_idx" ON "workflow_confirmations" ("workflowId");
+CREATE INDEX "workflow_confirmations_userId_idx" ON "workflow_confirmations" ("userId");
+CREATE INDEX "workflow_confirmations_expiresAt_idx" ON "workflow_confirmations" ("expiresAt");
+
+-- Foreign keys to enforce tenant and workflow scoping
+ALTER TABLE "workflow_permissions"
+  ADD CONSTRAINT "workflow_permissions_tenantId_fkey"
+    FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE CASCADE,
+  ADD CONSTRAINT "workflow_permissions_workflowId_fkey"
+    FOREIGN KEY ("workflowId") REFERENCES "workflows"("id") ON DELETE CASCADE,
+  ADD CONSTRAINT "workflow_permissions_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE;
+
+ALTER TABLE "workflow_confirmations"
+  ADD CONSTRAINT "workflow_confirmations_tenantId_fkey"
+    FOREIGN KEY ("tenantId") REFERENCES "tenants"("id") ON DELETE CASCADE,
+  ADD CONSTRAINT "workflow_confirmations_workflowId_fkey"
+    FOREIGN KEY ("workflowId") REFERENCES "workflows"("id") ON DELETE CASCADE,
+  ADD CONSTRAINT "workflow_confirmations_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -76,6 +76,8 @@ model Tenant {
   workflowExecutions WorkflowExecution[]
   workflowCredentials WorkflowCredential[]
   workflowAnalytics WorkflowAnalytics[]
+  workflowPermissions WorkflowPermission[]
+  workflowConfirmations WorkflowConfirmation[]
   apiConnections    ApiConnection[]
   oauth2Providers   OAuth2Provider[]
   oauth2Connections OAuth2Connection[]
@@ -121,6 +123,8 @@ model User {
   knowledgeFeedback     KnowledgeFeedback[]
   workflows             Workflow[]
   workflowCredentials   WorkflowCredential[]
+  workflowPermissions   WorkflowPermission[]
+  workflowConfirmations WorkflowConfirmation[]
   workflowTemplates     WorkflowTemplate[]
   oauth2Connections     OAuth2Connection[]
   triggerLogs           TriggerLog[]
@@ -559,6 +563,8 @@ model Workflow {
   creator    User                @relation(fields: [createdBy], references: [id], onDelete: Cascade)
   executions WorkflowExecution[]
   triggers   WorkflowTrigger[]
+  permissions WorkflowPermission[]
+  confirmations WorkflowConfirmation[]
 
   @@index([tenantId])
   @@index([status])
@@ -632,6 +638,49 @@ model WorkflowCredential {
   @@index([tenantId])
   @@index([service])
   @@map("workflow_credentials")
+}
+
+model WorkflowPermission {
+  id         String   @id @default(cuid())
+  tenantId   String
+  workflowId String
+  userId     String?
+  role       Role?
+  canView    Boolean  @default(false)
+  canExecute Boolean  @default(false)
+  canCancel  Boolean  @default(false)
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  tenant   Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  workflow Workflow @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+  user     User?    @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+  @@index([workflowId])
+  @@index([userId])
+  @@index([role])
+  @@map("workflow_permissions")
+}
+
+model WorkflowConfirmation {
+  id         String   @id
+  tenantId   String
+  workflowId String
+  userId     String
+  requestData Json
+  expiresAt  DateTime
+  createdAt  DateTime @default(now())
+
+  tenant   Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  workflow Workflow @relation(fields: [workflowId], references: [id], onDelete: Cascade)
+  user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([tenantId])
+  @@index([workflowId])
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("workflow_confirmations")
 }
 
 model WorkflowTemplate {

--- a/backend/src/integrations/__tests__/workflowExecutor.persistence.test.ts
+++ b/backend/src/integrations/__tests__/workflowExecutor.persistence.test.ts
@@ -1,0 +1,268 @@
+import { WorkflowExecutor, ExecutionRequest } from '../workflowExecutor';
+
+const workflowFindFirstMock = jest.fn();
+const userFindUniqueMock = jest.fn();
+const workflowPermissionFindFirstMock = jest.fn();
+const workflowExecutionCountMock = jest.fn();
+const workflowConfirmationCreateMock = jest.fn();
+const workflowConfirmationFindFirstMock = jest.fn();
+const workflowConfirmationDeleteManyMock = jest.fn();
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    workflow: {
+      findFirst: workflowFindFirstMock,
+    },
+    user: {
+      findUnique: userFindUniqueMock,
+    },
+    workflowPermission: {
+      findFirst: workflowPermissionFindFirstMock,
+    },
+    workflowExecution: {
+      count: workflowExecutionCountMock,
+    },
+    workflowConfirmation: {
+      create: workflowConfirmationCreateMock,
+      findFirst: workflowConfirmationFindFirstMock,
+      deleteMany: workflowConfirmationDeleteManyMock,
+    },
+  })),
+}));
+
+const workflowServiceOnMock = jest.fn();
+const workflowServiceExecuteMock = jest.fn();
+const workflowServiceRetryMock = jest.fn();
+const workflowServiceCancelMock = jest.fn();
+
+jest.mock('../../workflows/workflowService', () => ({
+  WorkflowService: jest.fn().mockImplementation(() => ({
+    on: workflowServiceOnMock,
+    executeWorkflow: workflowServiceExecuteMock,
+    retryExecution: workflowServiceRetryMock,
+    cancelExecution: workflowServiceCancelMock,
+  })),
+}));
+
+const getConversationContextMock = jest.fn();
+const getUserContextMock = jest.fn();
+
+jest.mock('../contextManager', () => ({
+  ContextManager: jest.fn().mockImplementation(() => ({
+    getConversationContext: getConversationContextMock,
+    getUserContext: getUserContextMock,
+  })),
+}));
+
+const generateConfirmationRequestMock = jest.fn();
+const generateCancellationResponseMock = jest.fn();
+const generateSuccessResponseMock = jest.fn();
+const generateErrorResponseMock = jest.fn();
+
+jest.mock('../responseHandler', () => ({
+  ResponseHandler: jest.fn().mockImplementation(() => ({
+    generateConfirmationRequest: generateConfirmationRequestMock,
+    generateCancellationResponse: generateCancellationResponseMock,
+    generateSuccessResponse: generateSuccessResponseMock,
+    generateErrorResponse: generateErrorResponseMock,
+  })),
+}));
+
+describe('WorkflowExecutor persistence integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    workflowFindFirstMock.mockResolvedValue({
+      id: 'wf-123',
+      tenantId: 'tenant-1',
+      status: 'active',
+      riskLevel: 'low',
+    });
+    userFindUniqueMock.mockResolvedValue({
+      id: 'user-1',
+      role: 'TENANT_USER',
+    });
+    workflowPermissionFindFirstMock.mockResolvedValue(null);
+    workflowExecutionCountMock.mockResolvedValue(0);
+    workflowConfirmationCreateMock.mockResolvedValue({
+      id: 'confirm-123',
+    });
+    workflowConfirmationFindFirstMock.mockResolvedValue(null);
+    workflowConfirmationDeleteManyMock.mockResolvedValue({ count: 1 });
+    workflowServiceExecuteMock.mockResolvedValue('exec-123');
+    getConversationContextMock.mockResolvedValue({});
+    getUserContextMock.mockResolvedValue({});
+    generateConfirmationRequestMock.mockResolvedValue({
+      type: 'confirmation',
+      content: { message: 'confirm' },
+      timestamp: new Date('2024-01-01T00:00:00.000Z'),
+    });
+  });
+
+  const buildRequest = (overrides: Partial<ExecutionRequest> = {}): ExecutionRequest => ({
+    workflowId: 'wf-123',
+    triggerMatch: {
+      workflowId: 'wf-123',
+      workflowName: 'Example Workflow',
+      triggerType: 'keyword',
+      matchedText: 'run workflow',
+      confidence: 0.9,
+      requiresConfirmation: false,
+      parameters: {},
+    },
+    chatContext: {
+      conversationId: 'conversation-1',
+      messageId: 'message-1',
+      messageContent: 'please run workflow',
+      messageType: 'user',
+      timestamp: new Date('2024-01-01T10:00:00.000Z'),
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      metadata: {},
+      previousMessages: [],
+    },
+    parameters: {},
+    ...overrides,
+  });
+
+  it('denies execution when a user-specific workflow permission forbids execution', async () => {
+    workflowPermissionFindFirstMock.mockResolvedValueOnce({
+      canExecute: false,
+    });
+
+    const executor = new WorkflowExecutor();
+    const request = buildRequest();
+
+    const result = await executor.executeWorkflow(request);
+
+    expect(result.status).toBe('failed');
+    expect(result.error).toBe('No execute permission for this workflow');
+    expect(workflowPermissionFindFirstMock).toHaveBeenCalledTimes(1);
+    expect(workflowPermissionFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        workflowId: 'wf-123',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      },
+    });
+    expect(workflowServiceExecuteMock).not.toHaveBeenCalled();
+    expect(workflowConfirmationCreateMock).not.toHaveBeenCalled();
+  });
+
+  it('persists confirmations and resumes execution after approval', async () => {
+    workflowPermissionFindFirstMock
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ canExecute: true })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ canExecute: true });
+
+    const executor = new WorkflowExecutor();
+    const request = buildRequest({
+      triggerMatch: {
+        workflowId: 'wf-123',
+        workflowName: 'Example Workflow',
+        triggerType: 'keyword',
+        matchedText: 'run workflow',
+        confidence: 0.9,
+        requiresConfirmation: true,
+        parameters: {},
+      },
+    });
+
+    const pendingResult = await executor.executeWorkflow(request);
+
+    expect(pendingResult.status).toBe('started');
+    expect(pendingResult.executionId).toMatch(/^confirm_/);
+    expect(generateConfirmationRequestMock).toHaveBeenCalledWith(
+      request.triggerMatch,
+      request.chatContext,
+      pendingResult.executionId,
+    );
+
+    expect(workflowConfirmationCreateMock).toHaveBeenCalledTimes(1);
+    const confirmationCreateArgs = workflowConfirmationCreateMock.mock.calls[0][0];
+    expect(confirmationCreateArgs).toMatchObject({
+      data: {
+        workflowId: 'wf-123',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      },
+    });
+    expect(confirmationCreateArgs.data.requestData.workflowId).toBe('wf-123');
+
+    expect(workflowPermissionFindFirstMock).toHaveBeenNthCalledWith(1, {
+      where: {
+        workflowId: 'wf-123',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      },
+    });
+    expect(workflowPermissionFindFirstMock).toHaveBeenNthCalledWith(2, {
+      where: {
+        workflowId: 'wf-123',
+        tenantId: 'tenant-1',
+        role: 'TENANT_USER',
+      },
+    });
+
+    const confirmationId = pendingResult.executionId;
+    const storedRequest: ExecutionRequest = {
+      ...request,
+      userConfirmed: undefined,
+    };
+    workflowConfirmationFindFirstMock.mockResolvedValueOnce({
+      id: confirmationId,
+      workflowId: 'wf-123',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      requestData: storedRequest,
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+
+    workflowServiceExecuteMock.mockResolvedValueOnce('exec-456');
+
+    const confirmationContext = {
+      ...request.chatContext,
+      messageId: 'message-2',
+      messageContent: 'yes',
+      timestamp: new Date('2024-01-01T10:01:00.000Z'),
+    };
+
+    const confirmedResult = await executor.handleUserConfirmation(
+      confirmationId,
+      true,
+      confirmationContext,
+    );
+
+    expect(workflowConfirmationFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        id: confirmationId,
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      },
+    });
+    expect(workflowConfirmationDeleteManyMock).toHaveBeenCalledWith({
+      where: {
+        id: confirmationId,
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      },
+    });
+
+    expect(workflowServiceExecuteMock).toHaveBeenCalledWith(
+      'wf-123',
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        metadata: expect.objectContaining({
+          triggerType: 'chat_message',
+          conversationId: 'conversation-1',
+          messageId: 'message-2',
+          source: 'chat_integration',
+        }),
+      }),
+    );
+    expect(confirmedResult.executionId).toBe('exec-456');
+    expect(confirmedResult.status).toBe('started');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tenant-scoped workflow permission and confirmation models to the Prisma schema with a migration
- enforce workflow executor permission checks and confirmation handling against the new persistence tables
- cover permission denial and confirmation resume flows with service-layer tests that mock Prisma interactions

## Testing
- npm test -- workflowExecutor.persistence

------
https://chatgpt.com/codex/tasks/task_b_68ca18f5a8f88323a7852e5498f9a697